### PR TITLE
Update disclaimer, copyright and footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,59 +1,32 @@
-<footer style="background-color: lightgrey; padding: 3rem; margin-top: 3rem">
+<footer role="contentinfo">
     <div class="nhsuk-footer" id="nhsuk-footer">
       <div class="nhsuk-width-container">
-        <div class="row">
-            <div class="col-lg">
-                <h2 class="nhsuk-u-visually-hidden">Support links</h2>
-                <ul class="nhsuk-footer__list">
-
-                <!-- <li class="nhsuk-footer__list-item">
-                    Developed by
-                    <a
-                    class="nhsuk-footer__list-item-link"
-                    href="{{ site.github.owner_url }}"
-                    >NHSX</a
-                    >
-                </li> -->
-
-                <li class="nhsuk-footer__list-item">
-                    View the Project on
-                    <a
-                    class="nhsuk-footer__list-item-link"
-                    href="{{ site.github.repository_url }}"
-                    >GitHub</a
-                    >
-                </li>
-
-                {% if site.email %}
-                    <li class="list-inline-item">
-                    <a href="mailto:{{ site.email }}">
-                        <span class="fa-stack fa-lg">
-                        <i class="fa fa-circle fa-stack-2x"></i>
-                        <i class="fa fa-envelope-o fa-stack-1x fa-inverse"></i>
-                        </span>
-                    </a>
-                    </li>
-                {% endif %}
-
-                {% if site.github_username %}
-                <li class="list-inline-item">
-                    <a href="https://github.com/{{ site.github_username }}">
-                    <span class="fa-stack fa-lg">
-                        <i class="fa fa-circle fa-stack-2x"></i>
-                        <i class="fa fa-github fa-stack-1x fa-inverse"></i>
-                    </span>
-                    </a>
-                </li>
-                {% endif %}
-
-                </ul>
-            </div>
-            <p class="copyright">
-                <b>DISCLAIMER</b> - This is not the official NHSX site but a store of technical documents and ongoing work from the NHSX analytics unit made for transparency and collaboration.  Opinions expressed in posts are not representative of the views of NHSX and any content here should <b>not</b> be regarded as official output in any form. For more information about NHSX please visit our official <a style="color: #CF3587" href="https://www.nhsx.nhs.uk/">website</a>.
-                </p>
-            <p class="copyright"><img src="/assets/1200px-UKOpenGovernmentLicence.svg.png" width="30" height="15"> © 2021 (<a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence</a> ≥ 3) 
-            <!-- <p class="nhsuk-footer__copyright">&copy; MIT</p> -->
-        </div>
+        <h2 class="nhsuk-u-visually-hidden">Support links</h2>
+        <ul class="nhsuk-footer__list">
+          <li class="nhsuk-footer__list-item"> View the Project on <a class="nhsuk-footer__list-item-link" href="{{ site.github.repository_url }}">GitHub</a></li>
+          <li class="nhsuk-footer__list-item"><a href="mailto:{{ site.email }}"><span class="fa-stack fa-lg">
+              <i class="fa fa-circle fa-stack-2x"></i>
+              <i class="fa fa-envelope-o fa-stack-1x fa-inverse"></i>
+            </span>
+            </a></li>
+          <li class="nhsuk-footer__list-item"><a href="https://github.com/{{ site.github_username }}"><span class="fa-stack fa-lg">
+                <i class="fa fa-circle fa-stack-2x"></i>
+                <i class="fa fa-github fa-stack-1x fa-inverse"></i>
+            </span>
+            </a></li>
+        </ul>
+  
+        <p class="nhsuk-footer__copyright">&copy; NHS England and Improvement</p>
       </div>
     </div>
+    <div class="app-ogl-footer">
+        <div class="nhsuk-width-container app-width-container" >
+          <p class="app-ogl-footer--text">
+            <svg xmlns="http://www.w3.org/2000/svg" height="17" width="41" focusable="false" viewBox="0 0 483.2 195.7">
+              <path fill="currentcolor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"></path>
+            </svg>
+            All content is available under the <a class="nhsuk-footer__list-item-link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated.
+          </p>
+        </div>
+      </div>
   </footer>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -12,12 +12,27 @@
           : "js-enabled";
     </script>
 
+    
+
     <div class="nhsuk-grid-row" style="margin-top: 6rem"></div>
 
     <div class="nhsuk-width-container">
         <main class="nhsuk-main-wrapper" id="maincontent" role="main">
           <div class="nhsuk-grid-row">
-            <div class="nhsuk-grid-column-full">{{ content }}</div>
+            <div class="nhsuk-grid-column-full">
+              
+              <div class="nhsuk-warning-callout">
+                <h3 class="nhsuk-warning-callout__label">
+                  <span role="text">
+                    <span class="nhsuk-u-visually-hidden">Important: </span>
+                    Disclaimer
+                  </span>
+                </h3>
+                <p>This is not the official NHSX site but a store of technical documents and ongoing work from the NHSX analytics unit made for transparency and collaboration.  Opinions expressed in posts are not representative of the views of NHSX and any content here should <b>not</b> be regarded as official output in any form. For more information about NHSX please visit our official <a style="color: #CF3587" href="https://www.nhsx.nhs.uk/">website</a></p>
+              </div>
+              
+              {{ content }}
+            </div>
           </div>
         </main>
     </div>


### PR DESCRIPTION
This moves the disclaimer to the top of the page and includes the OGL licence in the footer.  Unfortuantely, leaves a formatting issue with a different background colour.  "fill = "currentcolor" doesn't seem to work as expected.